### PR TITLE
refactor: use opcodes from sbpf-common crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,8 +812,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "sbpf-assembler"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe35fff08463e7e57b675d7cbf4fe103f84195246a0660d120fa81ccc1ed4eb3"
+source = "git+https://github.com/blueshift-gg/sbpf?branch=master#7eb6026388aa4015087d9941bd9660073f417743"
 dependencies = [
  "anyhow",
  "num-derive",
@@ -821,10 +820,20 @@ dependencies = [
  "object",
  "phf",
  "phf_macros",
+ "sbpf-common",
  "serde",
  "serde-wasm-bindgen",
  "thiserror 2.0.17",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "sbpf-common"
+version = "0.1.2"
+source = "git+https://github.com/blueshift-gg/sbpf?branch=master#7eb6026388aa4015087d9941bd9660073f417743"
+dependencies = [
+ "num-derive",
+ "num-traits",
 ]
 
 [[package]]
@@ -839,6 +848,7 @@ dependencies = [
  "llvm-sys 211.0.0",
  "object",
  "sbpf-assembler",
+ "sbpf-common",
  "thiserror 2.0.17",
  "tracing",
  "tracing-appender",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,9 @@ crate-type = ["cdylib", "lib"]
 name = "sbpf_linker"
 
 [dependencies]
-sbpf-assembler = "0.1.2"
+# TODO: replace git dependencies with tags after 0.1.3 version will be published on crates.io
+sbpf-assembler = { git = "https://github.com/blueshift-gg/sbpf", branch = "master" }
+sbpf-common = { git = "https://github.com/blueshift-gg/sbpf", branch = "master" }
 clap = { version = "4.5.13", features = ["derive"] }
 object = "0.37.3"
 bpf-linker = "0.9.15"

--- a/src/byteparser.rs
+++ b/src/byteparser.rs
@@ -2,8 +2,8 @@ use sbpf_assembler::ast::AST;
 use sbpf_assembler::astnode::{ASTNode, ROData};
 use sbpf_assembler::instruction::Instruction;
 use sbpf_assembler::lexer::{ImmediateValue, Token};
-use sbpf_assembler::opcode::Opcode;
 use sbpf_assembler::parser::ParseResult;
+use sbpf_common::opcode::Opcode;
 
 use object::RelocationTarget::Symbol;
 use object::{File, Object as _, ObjectSection as _, ObjectSymbol as _};


### PR DESCRIPTION
### Problem

after removing duplicate of opcodes introduced by https://github.com/blueshift-gg/sbpf/pull/43, opcodes by the previous path are not available

### Proposed Solution

import opcodes from `sbpf-common` crate