### PR TITLE
fix(cli): improve clap error handling for missing arguments

### DIFF
--- a/src/byteparser.rs
+++ b/src/byteparser.rs
@@ -66,7 +66,9 @@ pub fn parse_bytecode(bytes: &[u8]) -> Result<ParseResult, SbpfLinkerError> {
                 let node = &section.data().unwrap()[offset..offset + node_len];
                 let instruction = Instruction::from_bytes(node);
                 if let Err(error) = instruction {
-                    return Err(SbpfLinkerError::InstructionParseError(error.to_string()));
+                    return Err(SbpfLinkerError::InstructionParseError(
+                        error.to_string(),
+                    ));
                 } else {
                     ast.nodes.push(ASTNode::Instruction {
                         instruction: instruction.unwrap(),
@@ -84,8 +86,10 @@ pub fn parse_bytecode(bytes: &[u8]) -> Result<ParseResult, SbpfLinkerError> {
                         Symbol(sym) => Some(obj.symbol_by_index(sym).unwrap()),
                         _ => None,
                     };
-                
-                    if symbol.unwrap().section_index() == Some(ro_section.index()) {
+
+                    if symbol.unwrap().section_index()
+                        == Some(ro_section.index())
+                    {
                         // addend is not explicit in the relocation entry, but implicitly encoded
                         // as the immediate value of the instruction
                         let addend = match ast


### PR DESCRIPTION
## Problem

When sbpf-lniker runs without argument, it spews out error instead of the customary help message.

<img width="726" height="186" alt="image" src="https://github.com/user-attachments/assets/601eb1cd-5926-4aeb-b628-42d8d4838a13" />

## Solution

Delegate CLP argument parsing concerns to `clap`

<img width="726" height="579" alt="image" src="https://github.com/user-attachments/assets/97b41fd6-1ccc-48e7-928d-31013870a4d0" />