### PR TITLE
fix(byteparser): handle lddw relocations targeting .data.rel.ro

### DIFF
--- a/src/byteparser.rs
+++ b/src/byteparser.rs
@@ -32,10 +32,17 @@ pub fn parse_bytecode(bytes: &[u8]) -> Result<ParseResult, SbpfLinkerError> {
 
     let obj = File::parse(bytes)?;
 
-    // Track all .rodata* inputs, but keep AST rodata layout packed by node size.
+    // Track all read-only sections including .rodata* and .data.rel.ro* sections.
+    // .data.rel.ro* is read-only after load-time pointer patching and can be
+    // an lddw relocation target just like .rodata*.
     let mut ro_sections = HashMap::new();
     for section in obj.sections().filter(|section| {
-        section.name().map(|name| name.starts_with(".rodata")).unwrap_or(false)
+        section
+            .name()
+            .map(|name| {
+                name.starts_with(".rodata") || name.starts_with(".data.rel.ro")
+            })
+            .unwrap_or(false)
     }) {
         ro_sections.insert(section.index(), section);
     }

--- a/tests/assembly/data_rel_ro_lddw.rs
+++ b/tests/assembly/data_rel_ro_lddw.rs
@@ -1,0 +1,56 @@
+// assembly-output: ptx-linker
+// compile-flags: --crate-type bin -C opt-level=3 -C panic=abort
+
+// core::panic::Location structs land in .data.rel.ro when the panic handler
+// reads location fields and passes them to an opaque external. lddw
+// relocations targeting .data.rel.ro must resolve to the correct rodata
+// offsets.
+
+#![no_std]
+#![no_main]
+
+unsafe extern "C" {
+    fn sol_panic_(
+        file: *const u8,
+        len: u64,
+        line: u64,
+        col: u64,
+    ) -> !;
+}
+
+#[panic_handler]
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    let loc = info.location().unwrap();
+    unsafe {
+        sol_panic_(
+            loc.file().as_ptr(),
+            loc.file().len() as u64,
+            loc.line() as u64,
+            loc.column() as u64,
+        )
+    }
+}
+
+#[unsafe(no_mangle)]
+pub fn entrypoint(x: *mut u8) -> u64 {
+    let a: Option<u64> =
+        if unsafe { core::ptr::read_volatile(x as *const u64) } != 0 {
+            Some(1)
+        } else {
+            None
+        };
+    let b: Option<u64> =
+        if unsafe { core::ptr::read_volatile(x as *const u64) } != 1 {
+            Some(2)
+        } else {
+            None
+        };
+    a.unwrap() + b.unwrap()
+}
+
+// CHECK: rodata-count: 3
+// CHECK: rodata[0]: byte 116, 101, 115, 116, 115, 47, 97, 115, 115, 101, 109, 98, 108, 121, 47, 100, 97, 116, 97, 95, 114, 101, 108, 95, 114, 111, 95, 108, 100, 100, 119, 46, 114, 115, 0
+// CHECK: rodata[35]: byte 0, 0, 0, 0, 0, 0, 0, 0, 34, 0, 0, 0, 0, 0, 0, 0, 48, 0, 0, 0, 7, 0, 0, 0
+// CHECK: rodata[59]: byte 0, 0, 0, 0, 0, 0, 0, 0, 34, 0, 0, 0, 0, 0, 0, 0, 48, 0, 0, 0, 20, 0, 0, 0
+// CHECK: lddw r{{[0-9]+}}, rodata[35]
+// CHECK: lddw r{{[0-9]+}}, rodata[59]


### PR DESCRIPTION
The fix extends the `ro_sections` predicate to also match
`.data.rel.ro*`. The `.data.rel.ro*` section is read-only after load-time pointer patching and can be 
an `lddw` relocation target just like `.rodata*`. This is sufficient as the symbol loop, gap-fill pass,
and `rodata_table` all operate over `ro_sections` and require no further
changes if `.data.rel.ro*` ever needs gap-filling.

I verified against the reproduction case in
https://github.com/sonicfromnewyoke/linker-llm-mismatch with a clean build.

A couple of naming questions:

`ro_sections` and `rodata_table` now cover sections that are not strictly
rodata. The names still make sense as shorthand but are no longer precise.
Is it worth renaming them to something like `const_sections` and
`const_table` to reflect that the actual criterion is "read-only from the
program's perspective and a valid lddw target", not "named .rodata"?

Relatedly, the gap-fill pass names synthetic entries with the prefix
`.rodata.__anon_` regardless of which section the gap belongs to. If a
gap were ever found inside `.data.rel.ro`, the label would read
`.rodata.__anon_7_0x0` (cosmetically wrong but functionally harmless
since the name is only ever used as a lookup key). Do we leave it given it has no runtime
effect or fix the format string to use the actual section name?



Fixes #25 