### PR TITLE
fix: stop displaying version msg twice

### DIFF
--- a/src/bin/sbpf-linker.rs
+++ b/src/bin/sbpf-linker.rs
@@ -222,7 +222,7 @@ where
         Err(err) => match err.kind() {
             ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => {
                 print!("{err}");
-                return Err(err.into());
+                std::process::exit(0);
             }
             _ => return Err(err.into()),
         },


### PR DESCRIPTION
Current `--version` flag is showing duplicate messages 

```
sbpf-linker 0.1.9
Error: sbpf-linker 0.1.9
```