### PR TITLE
test(dfe): drop dead_self_recursive revision

### DIFF
--- a/tests/assembly/dfe_recursive.rs
+++ b/tests/assembly/dfe_recursive.rs
@@ -1,5 +1,5 @@
 // assembly-output: ptx-linker
-// revisions: live_self_recursive dead_self_recursive live_mutual_recursive
+// revisions: live_self_recursive live_mutual_recursive
 // compile-flags: --crate-type bin -C opt-level=3
 
 // Tests that DFE correctly handles recursive functions:
@@ -7,10 +7,6 @@
 // live_self_recursive  — a self-recursive function reachable from entrypoint
 //                        must survive DFE and its self-call must remain in
 //                        the linked binary.
-//
-// dead_self_recursive  — a self-recursive function never called from entrypoint
-//                        must be eliminated by DFE even though it has a
-//                        self-call edge in the CFG.
 //
 // live_mutual_recursive — two mutually recursive functions (ping <-> pong)
 //                         reachable from entrypoint must both survive DFE and
@@ -41,26 +37,6 @@ fn factorial(n: u64) -> u64 {
 #[unsafe(no_mangle)]
 pub fn entrypoint(_input: *mut u8) -> u64 {
     factorial(5)
-}
-
-// ── dead_self_recursive ──────────────────────────────────────────────────────
-
-// dead_recursive is never called from entrypoint. DFE must remove it even
-// though it has a self-call edge in the CFG.
-#[cfg(dead_self_recursive)]
-#[unsafe(no_mangle)]
-#[inline(never)]
-fn dead_recursive(n: u64) -> u64 {
-    if n == 0 {
-        return 0;
-    }
-    dead_recursive(n - 1)
-}
-
-#[cfg(dead_self_recursive)]
-#[unsafe(no_mangle)]
-pub fn entrypoint(_input: *mut u8) -> u64 {
-    42
 }
 
 // ── live_mutual_recursive ────────────────────────────────────────────────────
@@ -101,10 +77,6 @@ pub fn entrypoint(_input: *mut u8) -> u64 {
 // inside factorial's body must appear after the function label.
 // CHECK,live_self_recursive: label factorial
 // CHECK,live_self_recursive: call factorial
-
-// dead_recursive is unreachable — DFE must eliminate it entirely.
-// CHECK,dead_self_recursive: label entrypoint
-// CHECK,dead_self_recursive-NOT: label dead_recursive
 
 // Both ping and pong are reachable. Each function's cross-call must survive.
 // entrypoint comes first, then ping, then pong — matching the linked binary order.


### PR DESCRIPTION
`dead_self_recursive` was removed from the revisions list at `opt-level=3` LLVM folds the recursive function into a straight `r0=0; exit` with no call instruction
so the self-loop edge never exists in the binary and the revision wasn't testing what it claimed.