### PR TITLE
fix: improve LLVM backend diagnostics and setup

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,7 +13,12 @@ cargo install sbpf-linker
 
 ### LLVM Main: Early Feature Gate
 
-Builds and installs sbpf-linker against a cached [`llvm/llvm-project`](https://github.com/llvm/llvm-project) `main` checkout with static LLVM linking. The install command reuses the cached LLVM checkout and build when available.
+Some programs need BPF backend capabilities that are not available in older
+LLVM builds. Build and install sbpf-linker against a cached
+[`llvm/llvm-project`](https://github.com/llvm/llvm-project) `main` checkout
+with static LLVM linking. The install command checks for Git, CMake, and Ninja,
+installs missing Homebrew dependencies on macOS, and reuses the cached LLVM
+checkout and build when available.
 
 ```sh
 cargo install-with-llvm-main

--- a/Readme.md
+++ b/Readme.md
@@ -13,8 +13,7 @@ cargo install sbpf-linker
 
 ### LLVM Main: Early Feature Gate
 
-Some programs need BPF backend capabilities that are not available in older
-LLVM builds. Build and install sbpf-linker against a cached
+Build and install sbpf-linker against a cached
 [`llvm/llvm-project`](https://github.com/llvm/llvm-project) `main` checkout
 with static LLVM linking. The install command checks for Git, CMake, and Ninja,
 installs missing Homebrew dependencies on macOS, and reuses the cached LLVM

--- a/src/bin/sbpf-linker.rs
+++ b/src/bin/sbpf-linker.rs
@@ -176,7 +176,6 @@ struct CommandLine {
     override_cpu_flag: Option<Cpu>,
 
     /// Enable or disable CPU features. The available features are: alu32, dummy, dwarfris.
-    /// LLVM builds containing the BPF allows-misaligned-mem-access target feature support it.
     /// Use +feature to enable a feature, or -feature to disable it. For example
     /// --cpu-features=+allows-misaligned-mem-access,+alu32,-dwarfris
     #[clap(

--- a/src/bin/sbpf-linker.rs
+++ b/src/bin/sbpf-linker.rs
@@ -176,8 +176,8 @@ struct CommandLine {
     override_cpu_flag: Option<Cpu>,
 
     /// Enable or disable CPU features. The available features are: alu32, dummy, dwarfris.
-    /// LLVM 22 builds also support allows-misaligned-mem-access. Use +feature to enable a
-    /// feature, or -feature to disable it. For example
+    /// LLVM builds containing the BPF allows-misaligned-mem-access target feature support it.
+    /// Use +feature to enable a feature, or -feature to disable it. For example
     /// --cpu-features=+allows-misaligned-mem-access,+alu32,-dwarfris
     #[clap(
         long,
@@ -300,6 +300,17 @@ where
         .with_writer(writer)
 }
 
+fn llvm_version() -> (u32, u32, u32) {
+    let (mut major, mut minor, mut patch) = (0, 0, 0);
+    // SAFETY: LLVMGetVersion only writes to the three valid output pointers.
+    unsafe {
+        bpf_linker::llvm_sys::core::LLVMGetVersion(
+            &mut major, &mut minor, &mut patch,
+        );
+    }
+    (major, minor, patch)
+}
+
 fn process_cli_options<I>(args: I) -> anyhow::Result<CommandLine>
 where
     I: Iterator<Item = String>,
@@ -307,8 +318,14 @@ where
     let cli: CommandLine = match Parser::try_parse_from(args) {
         Ok(cli) => cli,
         Err(err) => match err.kind() {
-            ErrorKind::DisplayHelp | ErrorKind::DisplayVersion => {
+            ErrorKind::DisplayHelp => {
                 print!("{err}");
+                std::process::exit(0);
+            }
+            ErrorKind::DisplayVersion => {
+                print!("{err}");
+                let (major, minor, patch) = llvm_version();
+                println!("LLVM {major}.{minor}.{patch}");
                 std::process::exit(0);
             }
             _ => return Err(err.into()),

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -174,9 +174,6 @@ fn build_llvm_if_needed(
             })?;
         }
 
-        if cfg!(target_os = "macos") {
-            ensure_brew_dependencies()?;
-        }
         // Build only the LLVM components needed by sbpf-linker.
         let mut install_arg = OsString::from("-DCMAKE_INSTALL_PREFIX=");
         install_arg.push(paths.install_dir.as_os_str());
@@ -269,6 +266,7 @@ fn build_llvm_if_needed(
 }
 
 fn install() -> Result<()> {
+    ensure_build_dependencies()?;
     let paths = llvm_paths()?;
     let checkout_changed = ensure_llvm_checkout(&paths.src_dir)?;
     build_llvm_if_needed(&paths, checkout_changed)?;
@@ -280,6 +278,7 @@ fn install() -> Result<()> {
 }
 
 fn update_llvm() -> Result<()> {
+    ensure_build_dependencies()?;
     let paths = llvm_paths()?;
     let checkout_changed = update_llvm_checkout(&paths.src_dir)?;
     build_llvm_if_needed(&paths, checkout_changed)
@@ -291,8 +290,6 @@ fn build_linker(llvm_install_dir: &Path) -> Result<()> {
     let mut cmd = Command::new("cargo");
 
     if cfg!(target_os = "macos") {
-        ensure_brew_dependencies()?;
-
         // Ensure brew prefixes
         let llvm_output = Command::new("brew")
             .args(["--prefix", "llvm"])
@@ -393,31 +390,60 @@ fn run_command(cmd: &mut Command, description: &str) -> Result<()> {
     Ok(())
 }
 
-// On macOS, use Homebrew's llvm for libc++, zlib, and zstd
-// (macOS doesn't provide static libraries, and building them from source is complex)
+// On macOS, use Homebrew for the build tools and native libraries.
 fn ensure_brew_dependencies() -> Result<()> {
-    let llvm_installed = Command::new("brew")
-        .args(["--prefix", "llvm"])
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false);
-    let zlib_installed = Command::new("brew")
-        .args(["--prefix", "zlib"])
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false);
-    let zstd_installed = Command::new("brew")
-        .args(["--prefix", "zstd"])
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false);
+    if !command_available("brew") {
+        anyhow::bail!(
+            "Homebrew is required to install sbpf-linker on macOS\nhelp: install Homebrew from https://brew.sh and retry"
+        );
+    }
 
-    if !llvm_installed || !zlib_installed || !zstd_installed {
-        println!("  Installing Homebrew dependencies (llvm, zlib, zstd)...");
-        run_command(
-            Command::new("brew").args(["install", "llvm", "zlib", "zstd"]),
-            "install brew dependencies",
-        )?;
+    let formulas = ["cmake", "ninja", "llvm", "zlib", "zstd"];
+    let missing = formulas
+        .into_iter()
+        .filter(|formula| {
+            Command::new("brew")
+                .args(["list", "--versions", formula])
+                .output()
+                .map_or(true, |output| {
+                    !output.status.success() || output.stdout.is_empty()
+                })
+        })
+        .collect::<Vec<_>>();
+
+    if !missing.is_empty() {
+        println!(
+            "Installing missing Homebrew dependencies: {}",
+            missing.join(", ")
+        );
+        let mut command = Command::new("brew");
+        command.arg("install").args(missing);
+        run_command(&mut command, "install Homebrew dependencies")?;
+    }
+    Ok(())
+}
+
+fn command_available(command: &str) -> bool {
+    Command::new(command)
+        .arg("--version")
+        .output()
+        .is_ok_and(|output| output.status.success())
+}
+
+fn ensure_build_dependencies() -> Result<()> {
+    if cfg!(target_os = "macos") {
+        ensure_brew_dependencies()?;
+    }
+
+    let missing = ["git", "cmake", "ninja"]
+        .into_iter()
+        .filter(|command| !command_available(command))
+        .collect::<Vec<_>>();
+    if !missing.is_empty() {
+        anyhow::bail!(
+            "missing required build tools: {}\nhelp: install them with your system package manager and retry",
+            missing.join(", ")
+        );
     }
     Ok(())
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -390,49 +390,44 @@ fn run_command(cmd: &mut Command, description: &str) -> Result<()> {
     Ok(())
 }
 
-// On macOS, use Homebrew for the build tools and native libraries.
-fn ensure_brew_dependencies() -> Result<()> {
-    if !command_available("brew") {
-        anyhow::bail!(
-            "Homebrew is required to install sbpf-linker on macOS\nhelp: install Homebrew from https://brew.sh and retry"
-        );
-    }
-
-    let formulas = ["cmake", "ninja", "llvm", "zlib", "zstd"];
-    let missing = formulas
-        .into_iter()
-        .filter(|formula| {
-            Command::new("brew")
-                .args(["list", "--versions", formula])
-                .output()
-                .map_or(true, |output| {
-                    !output.status.success() || output.stdout.is_empty()
-                })
-        })
-        .collect::<Vec<_>>();
-
-    if !missing.is_empty() {
-        println!(
-            "Installing missing Homebrew dependencies: {}",
-            missing.join(", ")
-        );
-        let mut command = Command::new("brew");
-        command.arg("install").args(missing);
-        run_command(&mut command, "install Homebrew dependencies")?;
-    }
-    Ok(())
-}
-
-fn command_available(command: &str) -> bool {
-    Command::new(command)
-        .arg("--version")
-        .output()
-        .is_ok_and(|output| output.status.success())
-}
-
 fn ensure_build_dependencies() -> Result<()> {
+    fn command_available(command: &str) -> bool {
+        Command::new(command)
+            .arg("--version")
+            .output()
+            .is_ok_and(|output| output.status.success())
+    }
+
     if cfg!(target_os = "macos") {
-        ensure_brew_dependencies()?;
+        if !command_available("brew") {
+            anyhow::bail!(
+                "Homebrew is required to install sbpf-linker on macOS\nhelp: install Homebrew from https://brew.sh and retry"
+            );
+        }
+
+        // On macOS, use Homebrew for the build tools and native libraries.
+        let formulas = ["cmake", "ninja", "llvm", "zlib", "zstd"];
+        let missing = formulas
+            .into_iter()
+            .filter(|formula| {
+                Command::new("brew")
+                    .args(["list", "--versions", formula])
+                    .output()
+                    .map_or(true, |output| {
+                        !output.status.success() || output.stdout.is_empty()
+                    })
+            })
+            .collect::<Vec<_>>();
+
+        if !missing.is_empty() {
+            println!(
+                "Installing missing Homebrew dependencies: {}",
+                missing.join(", ")
+            );
+            let mut command = Command::new("brew");
+            command.arg("install").args(missing);
+            run_command(&mut command, "install Homebrew dependencies")?;
+        }
     }
 
     let missing = ["git", "cmake", "ninja"]


### PR DESCRIPTION
## Summary

  This PR improves visibility into the LLVM backend loaded by `sbpf-linker` and makes the LLVM-main installation workflow more reliable.

  It:

  - Includes the loaded LLVM version in `sbpf-linker --version`.
  - Checks for Git, CMake, and Ninja before cloning or building LLVM.
  - Verifies that Homebrew is available on macOS and installs only missing dependencies.
  - Runs these checks during both installation and LLVM updates.
  - Clarifies that `allows-misaligned-mem-access` is an LLVM BPF backend capability, not a guarantee associated with an LLVM major version.
  - Documents the updated installation behavior.

  Example output:

  ```text
  sbpf-linker 0.1.9
  LLVM 21.1.8
  ```

  ## Motivation

  `cargo build-sbpf` can fail during linking even when `sbpf-linker` is installed and accepts the expected CLI arguments.

  I encountered two difficult-to-diagnose cases:

  1. The LLVM-main installer cloned LLVM and then failed with `No such file or directory` because CMake or Ninja was missing.
  2. The loaded LLVM BPF backend could not lower a compiler fence and aborted with `Cannot select: AtomicFence`.

  The `sbpf-linker` package version does not identify its LLVM backend. Two `sbpf-linker 0.1.9` binaries can be linked against different LLVM builds and
  provide different backend capabilities.

  The linker executable is therefore the authoritative place to report which LLVM library it loaded. Exposing that information allows downstream tools such as
  `cargo-build-sbpf` to provide useful diagnostics without relying on the linker package version alone.

  Checking dependencies before beginning the LLVM build also avoids late failures after an expensive clone or compilation has already started.