### PR TITLE
fix: migrate opcode group checks to the OpcodeTable trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ crate-type = ["cdylib", "lib"]
 name = "sbpf_linker"
 
 [dependencies]
-sbpf-assembler = "0.3.0"
-sbpf-common = "0.3.0"
+sbpf-assembler = "0.4.0"
+sbpf-common = "0.4.0"
 clap = { workspace = true }
 either = { version = "1.16.0", features = ["serde"] }
 object = { version = "0.40.0", features = ["write"] }

--- a/src/fuse_args_stack.rs
+++ b/src/fuse_args_stack.rs
@@ -3,8 +3,8 @@ use sbpf_assembler::CompileError;
 use sbpf_assembler::ast::AST;
 use sbpf_assembler::astnode::ASTNode;
 use sbpf_common::{
-    instruction::Instruction,
-    opcode::{LOAD_MEMORY_OPS, Opcode, STORE_IMM_OPS, STORE_REG_OPS},
+    OpcodeTable, instruction::Instruction, opcode::Opcode,
+    optype::OperationType,
 };
 use std::ops::Range;
 
@@ -49,16 +49,13 @@ pub fn diagnose_stack_arg_overlaps(
             Opcode::Ldxdw | Opcode::Stdw | Opcode::Stxdw => 8,
             _ => return None,
         };
-        let (register, is_load) =
-            if LOAD_MEMORY_OPS.contains(&instruction.opcode) {
-                (instruction.src.as_ref()?.n, true)
-            } else if STORE_IMM_OPS.contains(&instruction.opcode)
-                || STORE_REG_OPS.contains(&instruction.opcode)
-            {
+        let (register, is_load) = match instruction.opcode.group() {
+            OperationType::LoadMemory => (instruction.src.as_ref()?.n, true),
+            OperationType::StoreImmediate | OperationType::StoreRegister => {
                 (instruction.dst.as_ref()?.n, false)
-            } else {
-                return None;
-            };
+            }
+            _ => return None,
+        };
 
         Some(MemoryAccess { register, offset, width, is_load })
     };
@@ -124,9 +121,12 @@ pub fn rewrite_r11_stack_args(
             continue;
         }
 
-        let is_load = LOAD_MEMORY_OPS.contains(&instruction.opcode);
-        let is_store = STORE_IMM_OPS.contains(&instruction.opcode)
-            || STORE_REG_OPS.contains(&instruction.opcode);
+        let group = instruction.opcode.group();
+        let is_load = group == OperationType::LoadMemory;
+        let is_store = matches!(
+            group,
+            OperationType::StoreImmediate | OperationType::StoreRegister
+        );
         assert!(
             is_load || is_store,
             "r11 must only be used by memory load/store instructions"


### PR DESCRIPTION
## Problem 

blueshift-gg/sbpf#159 moved opcode handling to tablegen and deleted three constants consumed in `fuse_args_stack.rs`. `Opcode` now implements `sbpf_common::OpcodeTable`, whose `group()` returns the `OperationType` the constants used to enumerate. 

## Summary of Changes

Replace the `LOAD_MEMORY_OPS` / `STORE_IMM_OPS` / `STORE_REG_OPS` slice lookups in `fuse_args_stack.rs` with `Opcode::group()`, and bump `sbpf-assembler` and `sbpf-common` from 0.3.0 to 0.4.0.


## Blocked on

sbpf 0.4.0 is not published yet. `Cargo.lock` still pins 0.3.0 and can't be regenerated until it is, so CI will fail at dependency resolution rather than at compile. I’ll leave it as a draft until the crates are up, then update the lockfile and mark ready.