### PR TITLE
feat: support v0 stack frame gaps

### DIFF
--- a/src/bin/sbpf-linker.rs
+++ b/src/bin/sbpf-linker.rs
@@ -40,6 +40,8 @@ enum CliError {
         "sBPF architecture `v0` only supports CPU architectures `generic`, `v1`, or `v2` (instead was `{0}`)"
     )]
     UnsupportedV0Cpu(Cpu),
+    #[error("`--enable-stack-frame-gaps` is only supported with `--arch=v0`")]
+    StackFrameGapsRequireV0,
 
     #[error(
         "invalid `-bpf-stack-size` value `{0}`; expected a positive value that fits in i32"
@@ -261,6 +263,17 @@ struct CommandLine {
     #[clap(long, default_value = "v3")]
     arch: CliArch,
 
+    /// Enable pre-SIMD-0460 stack-frame gaps (sBPF v0 only).
+    #[clap(
+        long,
+        action = clap::ArgAction::Set,
+        num_args = 0..=1,
+        default_missing_value = "true",
+        default_value_t = false,
+        default_value_if("arch", "v0", "true")
+    )]
+    enable_stack_frame_gaps: bool,
+
     /// Extra command line arguments to pass to LLVM
     #[clap(long, value_name = "args", use_value_delimiter = true, action = clap::ArgAction::Append)]
     llvm_args: Vec<CString>,
@@ -413,6 +426,9 @@ where
     }
 
     let cpu = cli.override_cpu_flag.unwrap();
+    if cli.enable_stack_frame_gaps && !matches!(cli.arch.0, SbpfArch::V0) {
+        return Err(CliError::StackFrameGapsRequireV0.into());
+    }
     if matches!(cli.arch.0, SbpfArch::V0)
         && !matches!(cpu, Cpu::Generic | Cpu::V1 | Cpu::V2)
     {
@@ -439,6 +455,7 @@ where
         dump_cfg_dir: cli.dump_cfg_dir,
         sbpf_optimize: cli.sbpf_optimize,
         arch: cli.arch,
+        enable_stack_frame_gaps: cli.enable_stack_frame_gaps,
         llvm_args,
         disable_expand_memcpy_in_order: cli.disable_expand_memcpy_in_order,
         disable_memory_builtins: cli.disable_memory_builtins,
@@ -474,6 +491,7 @@ fn main() -> anyhow::Result<()> {
         dump_cfg_dir,
         sbpf_optimize,
         arch,
+        enable_stack_frame_gaps,
         disable_expand_memcpy_in_order,
         disable_memory_builtins,
         mut inputs,
@@ -581,7 +599,12 @@ fn main() -> anyhow::Result<()> {
     };
     let bytecode = link_program(
         &program,
-        ProgramOptions::new(sbpf_optimization, arch.0, stack_frame_size),
+        ProgramOptions::new(
+            sbpf_optimization,
+            arch.0,
+            stack_frame_size,
+            enable_stack_frame_gaps,
+        ),
     )?;
 
     let src_name = std::path::Path::new(&output)
@@ -890,5 +913,39 @@ mod tests {
                 "sBPF architecture `v0` only supports CPU architectures"
             ));
         }
+    }
+
+    #[test]
+    fn test_stack_frame_gaps_require_sbpf_v0() {
+        let unsupported = [
+            "sbpf-linker",
+            "input.o",
+            "-o",
+            "/tmp/bin.o",
+            "--enable-stack-frame-gaps",
+        ]
+        .into_iter()
+        .map(str::to_string);
+
+        let error = process_cli_options(unsupported).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "`--enable-stack-frame-gaps` is only supported with `--arch=v0`"
+        );
+
+        let supported = [
+            "sbpf-linker",
+            "input.o",
+            "-o",
+            "/tmp/bin.o",
+            "--arch=v0",
+            "--enable-stack-frame-gaps",
+        ]
+        .into_iter()
+        .map(str::to_string);
+
+        let CommandLine { enable_stack_frame_gaps, .. } =
+            process_cli_options(supported).unwrap();
+        assert!(enable_stack_frame_gaps);
     }
 }

--- a/src/byteparser.rs
+++ b/src/byteparser.rs
@@ -45,7 +45,12 @@ pub fn parse_bytecode(
     bytes: &[u8],
     options: ProgramOptions,
 ) -> Result<ProgramLayout, SbpfLinkerError> {
-    let ProgramOptions { optimization, arch, stack_frame_size } = options;
+    let ProgramOptions {
+        optimization,
+        arch,
+        stack_frame_size,
+        stack_frame_gaps,
+    } = options;
     let mut ast = AST::new();
 
     let obj = File::parse(bytes)?;
@@ -440,7 +445,7 @@ pub fn parse_bytecode(
         );
     }
 
-    rewrite_r11_stack_args(&mut ast, stack_frame_size)
+    rewrite_r11_stack_args(&mut ast, stack_frame_size, stack_frame_gaps)
         .map_err(|errors| SbpfLinkerError::BuildProgramError { errors })?;
 
     let mut parse_result = build_program(ast, arch, optimization)

--- a/src/fuse_args_stack.rs
+++ b/src/fuse_args_stack.rs
@@ -110,8 +110,10 @@ pub fn diagnose_stack_arg_overlaps(
 pub fn rewrite_r11_stack_args(
     ast: &mut AST,
     stack_frame_size: i32,
+    stack_frame_gaps: bool,
 ) -> Result<(), Vec<CompileError>> {
     let mut errors = Vec::new();
+    let gap_adjustment = if stack_frame_gaps { stack_frame_size } else { 0 };
 
     for node in ast.nodes.iter_mut() {
         let ASTNode::Instruction { instruction, offset } = node else {
@@ -169,7 +171,13 @@ pub fn rewrite_r11_stack_args(
                 "an outgoing r11 store must have a negative offset"
             );
 
-            let Some(new_off) = off.checked_neg() else {
+            let Some(new_off) = off
+                .checked_neg()
+                .and_then(|offset| {
+                    i32::from(offset).checked_add(gap_adjustment)
+                })
+                .and_then(|offset| i16::try_from(offset).ok())
+            else {
                 errors.push(CompileError::BytecodeError {
                     error: format!(
                         "cannot rewrite r11 store at byte offset {offset:#x}: negating offset {off} does not fit in a BPF instruction offset"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ pub struct ProgramOptions {
     pub optimization: OptimizationConfig,
     pub arch: SbpfArch,
     pub stack_frame_size: i32,
+    pub stack_frame_gaps: bool,
 }
 
 impl ProgramOptions {
@@ -47,8 +48,9 @@ impl ProgramOptions {
         optimization: OptimizationConfig,
         arch: SbpfArch,
         stack_frame_size: i32,
+        stack_frame_gaps: bool,
     ) -> Self {
-        Self { optimization, arch, stack_frame_size }
+        Self { optimization, arch, stack_frame_size, stack_frame_gaps }
     }
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -258,6 +258,7 @@ fn render_emitted_program<A: TestArch>(path: &Path) -> anyhow::Result<String> {
             OptimizationConfig::enabled(),
             A::ARCH,
             DEFAULT_STACK_FRAME_SIZE,
+            matches!(A::ARCH, SbpfArch::V0),
         ),
     )?;
     let ph_count = if parse_result.prog_is_static { 1u64 } else { 3u64 };


### PR DESCRIPTION
this PR adds `--enable-stack-frame-gaps` for pre-SIMD-0460 sBPF v0 runtimes and adjusts outgoing R11 stack-argument offsets by the configured stack-frame size.