### PR TITLE
fix: handle rodata relocations

### DIFF
--- a/src/byteparser.rs
+++ b/src/byteparser.rs
@@ -35,7 +35,10 @@ fn decode_instruction_for_arch(
 // address and fill anonymous gaps before the AST is built.
 struct RodataEntry {
     section_index: SectionIndex,
+    // Offset within the original input section
     address: u64,
+    // Offset within the combined rodata section in the output
+    address_out: u64,
     size: u64,
     name: String,
     bytes: Vec<Number>,
@@ -74,8 +77,6 @@ pub fn parse_bytecode(
         text_size += section.size();
     }
     let mut pending_rodata: Vec<RodataEntry> = Vec::new();
-    let mut rodata_table: HashMap<(Option<SectionIndex>, u64), String> =
-        HashMap::new();
 
     let mut function_starts = Vec::new();
     for symbol in obj.symbols() {
@@ -104,6 +105,7 @@ pub fn parse_bytecode(
             pending_rodata.push(RodataEntry {
                 section_index: ro_section.index(),
                 address: symbol.address(),
+                address_out: 0,
                 size: symbol.size(),
                 name: symbol.name().unwrap().to_owned(),
                 bytes,
@@ -173,6 +175,7 @@ pub fn parse_bytecode(
                 synthetic_rodata.push(RodataEntry {
                     section_index: *section_index,
                     address: cursor,
+                    address_out: 0,
                     size: entry.address - cursor,
                     name: format!(
                         ".rodata.__anon_{:#x}_{:#x}",
@@ -192,6 +195,7 @@ pub fn parse_bytecode(
             synthetic_rodata.push(RodataEntry {
                 section_index: *section_index,
                 address: cursor,
+                address_out: 0,
                 size: section_size - cursor,
                 name: format!(
                     ".rodata.__anon_{:#x}_{:#x}",
@@ -205,26 +209,96 @@ pub fn parse_bytecode(
     pending_rodata.extend(synthetic_rodata);
     pending_rodata.sort_by_key(|e| (e.section_index.0, e.address));
 
-    let mut rodata_offset = 0u64;
-    for entry in pending_rodata {
-        ast.rodata_nodes.push(ASTNode::ROData {
-            rodata: ROData {
-                name: entry.name.clone(),
-                args: vec![
-                    Token::Directive(String::from("byte"), 0..1),
-                    Token::VectorLiteral(entry.bytes, 0..1),
-                ],
-                span: 0..1,
-            },
-            offset: rodata_offset,
-        });
-        rodata_table
-            .insert((Some(entry.section_index), entry.address), entry.name);
-        rodata_offset += entry.size;
+    // Calculate each rodata entry's output offset.
+    let mut rodata_size = 0u64;
+    for entry in &mut pending_rodata {
+        entry.address_out = rodata_size;
+        rodata_size += entry.size;
+    }
+
+    // Function to resolve an input section address to it's offset in the output rodata.
+    let resolve_rodata_output_offset =
+        |section: SectionIndex, input_address: u64| {
+            pending_rodata.iter().find_map(|entry| {
+                (entry.section_index == section
+                    && (entry.address..entry.address + entry.size)
+                        .contains(&input_address))
+                .then(|| entry.address_out + (input_address - entry.address))
+            })
+        };
+
+    // Map each rodata relocation to its output offset and target label.
+    let mut rodata_target_labels: HashMap<u64, String> = HashMap::new();
+    let mut rodata_target_nodes = Vec::new();
+    for (section_index, ro_section) in &ro_sections {
+        let section_name = ro_section.name().unwrap_or("<invalid>");
+        let section_data = ro_section.data()?;
+        for (relocation_address, rel) in ro_section.relocations() {
+            let relocation_error =
+                |detail: &str| SbpfLinkerError::RodataRelocationError {
+                    section: section_name.to_owned(),
+                    address: relocation_address,
+                    detail: detail.to_owned(),
+                };
+
+            let Symbol(symbol_index) = rel.target() else {
+                return Err(relocation_error("invalid relocation target"));
+            };
+            let symbol = obj.symbol_by_index(symbol_index)?;
+            let target_section = symbol.section_index().ok_or_else(|| {
+                relocation_error("relocation target has no section")
+            })?;
+            let addend = if rel.has_implicit_addend() {
+                let stored = section_data
+                    .get(
+                        relocation_address as usize
+                            ..relocation_address as usize + 8,
+                    )
+                    .ok_or_else(|| {
+                        relocation_error("relocation location out of bounds")
+                    })?;
+                i64::from_le_bytes(stored.try_into().unwrap())
+            } else {
+                rel.addend()
+            };
+            let relocation_offset = resolve_rodata_output_offset(
+                *section_index,
+                relocation_address,
+            )
+            .ok_or_else(|| {
+                relocation_error("relocation location is not rodata")
+            })?;
+
+            let target = symbol.address().wrapping_add(addend as u64);
+
+            let target_name = resolve_rodata_label(
+                target_section,
+                target,
+                &pending_rodata,
+                &mut rodata_target_labels,
+                &mut rodata_target_nodes,
+            )
+            .or_else(|| {
+                resolve_text_label(
+                    target_section,
+                    target,
+                    &text_section_bases,
+                    text_size,
+                    &mut labels_by_offset,
+                    &mut synthetic_labels_by_offset,
+                )
+            })
+            .ok_or_else(|| {
+                relocation_error("relocation target is not rodata or text")
+            })?;
+
+            // Add the relocation to the AST.
+            ast.add_rodata_relocation(relocation_offset, target_name);
+        }
     }
 
     let mut debug_sections = Vec::default();
-    ast.set_rodata_size(rodata_offset);
+    ast.set_rodata_size(rodata_size);
 
     for section in obj.sections() {
         if let Some(section_base) = text_section_bases.get(&section.index()) {
@@ -271,21 +345,60 @@ pub fn parse_bytecode(
                     .unwrap();
 
                 if node.opcode == Opcode::Lddw {
-                    // addend is not explicit in the relocation entry, but implicitly
-                    // encoded as the immediate value of the instruction
-                    let addend = match node.imm {
-                        Some(Either::Right(Number::Int(val))) => val,
-                        _ => 0,
-                    };
+                    let relocation_error =
+                        |detail: &str| SbpfLinkerError::LddwRelocationError {
+                            section: section_name.clone(),
+                            address: rel.0,
+                            detail: detail.to_owned(),
+                        };
 
-                    let key = (symbol.section_index(), addend as u64);
-                    if rodata_table.contains_key(&key) {
-                        // Replace the immediate value with the rodata label
-                        let ro_label = rodata_table[&key].clone();
-                        node.imm = Some(Either::Left(ro_label));
+                    let addend = if rel_has_implicit_addend {
+                        match node.imm {
+                            Some(Either::Right(
+                                Number::Int(val) | Number::Addr(val),
+                            )) => val,
+                            _ => rel_addend,
+                        }
                     } else {
-                        panic!("relocation in lddw is not in .rodata");
-                    }
+                        rel_addend
+                    };
+                    let target_section =
+                        symbol.section_index().ok_or_else(|| {
+                            relocation_error(
+                                "relocation target has no section",
+                            )
+                        })?;
+                    let target = symbol
+                        .address()
+                        .checked_add_signed(addend)
+                        .ok_or_else(|| {
+                        relocation_error("relocation target overflow")
+                    })?;
+
+                    let target_name = resolve_rodata_label(
+                        target_section,
+                        target,
+                        &pending_rodata,
+                        &mut rodata_target_labels,
+                        &mut rodata_target_nodes,
+                    )
+                    .or_else(|| {
+                        resolve_text_label(
+                            target_section,
+                            target,
+                            &text_section_bases,
+                            text_size,
+                            &mut labels_by_offset,
+                            &mut synthetic_labels_by_offset,
+                        )
+                    })
+                    .ok_or_else(|| {
+                        relocation_error(
+                            "relocation target is not rodata or text",
+                        )
+                    })?;
+                    // Replace the immediate value with the rodata label
+                    node.imm = Some(Either::Left(target_name));
                 } else if node.opcode == Opcode::Call {
                     if symbol.kind() == object::SymbolKind::Section {
                         let addend_i64 = if rel_has_implicit_addend {
@@ -375,6 +488,21 @@ pub fn parse_bytecode(
         }
     }
 
+    ast.rodata_nodes.extend(rodata_target_nodes);
+    for entry in pending_rodata {
+        ast.rodata_nodes.push(ASTNode::ROData {
+            rodata: ROData {
+                name: entry.name,
+                args: vec![
+                    Token::Directive(String::from("byte"), 0..1),
+                    Token::VectorLiteral(entry.bytes, 0..1),
+                ],
+                span: 0..1,
+            },
+            offset: entry.address_out,
+        });
+    }
+
     if !synthetic_labels_by_offset.is_empty() {
         // Add synthetic labels to AST
         let mut synthetic_labels =
@@ -449,4 +577,63 @@ pub fn parse_bytecode(
     parse_result.debug_sections = debug_sections;
 
     Ok(parse_result)
+}
+
+fn resolve_rodata_label(
+    section: SectionIndex,
+    address: u64,
+    entries: &[RodataEntry],
+    labels: &mut HashMap<u64, String>,
+    nodes: &mut Vec<ASTNode>,
+) -> Option<String> {
+    let entry = entries.iter().find(|entry| {
+        entry.section_index == section
+            && (entry.address..entry.address + entry.size).contains(&address)
+    })?;
+    let offset = entry.address_out + address - entry.address;
+    if offset == entry.address_out {
+        return Some(entry.name.clone());
+    }
+    if let Some(name) = labels.get(&offset) {
+        return Some(name.clone());
+    }
+
+    let name = format!(".rodata.__at__{offset:#x}");
+    nodes.push(ASTNode::ROData {
+        rodata: ROData {
+            name: name.clone(),
+            args: vec![
+                Token::Directive(String::from("byte"), 0..1),
+                Token::VectorLiteral(Vec::new(), 0..1),
+            ],
+            span: 0..1,
+        },
+        offset,
+    });
+    labels.insert(offset, name.clone());
+    Some(name)
+}
+
+fn resolve_text_label(
+    section: SectionIndex,
+    address: u64,
+    section_bases: &HashMap<SectionIndex, u64>,
+    text_size: u64,
+    labels: &mut HashMap<u64, String>,
+    synthetic_labels: &mut HashMap<u64, String>,
+) -> Option<String> {
+    let offset = section_bases
+        .get(&section)?
+        .checked_add(address)
+        .filter(|offset| *offset < text_size)?;
+    if let Some(name) = labels.get(&offset) {
+        return Some(name.clone());
+    }
+
+    let name = synthetic_labels
+        .entry(offset)
+        .or_insert_with(|| format!(".text.__at__{offset:#x}"))
+        .clone();
+    labels.insert(offset, name.clone());
+    Some(name)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,14 @@ pub enum SbpfLinkerError {
         abs_off: u64,
         addend: i64,
     },
+    #[error(
+        "Error handling lddw relocation in section={section} address={address:#x}: {detail}"
+    )]
+    LddwRelocationError { section: String, address: u64, detail: String },
+    #[error(
+        "Error handling rodata relocation in section={section} address={address:#x}: {detail}"
+    )]
+    RodataRelocationError { section: String, address: u64, detail: String },
 }
 
 #[derive(Debug, Clone)]

--- a/tests/assembly/data_rel_ro_lddw.rs
+++ b/tests/assembly/data_rel_ro_lddw.rs
@@ -50,7 +50,9 @@ pub fn entrypoint(x: *mut u8) -> u64 {
 
 // CHECK: rodata-count: 4
 // CHECK: rodata[0]: byte 116, 101, 115, 116, 115, 47, 97, 115, 115, 101, 109, 98, 108, 121, 47, 100, 97, 116, 97, 95, 114, 101, 108, 95, 114, 111, 95, 108, 100, 100, 119, 46, 114, 115, 0
-// CHECK: rodata[35]: byte 0, 0, 0, 0, 0, 0, 0, 0, 34, 0, 0, 0, 0, 0, 0, 0, 48, 0, 0, 0, 7, 0, 0, 0
-// CHECK: rodata[59]: byte 0, 0, 0, 0, 0, 0, 0, 0, 34, 0, 0, 0, 0, 0, 0, 0, 48, 0, 0, 0, 20, 0, 0, 0
+// CHECK: rodata[35]: byte {{.*}}, 34, 0, 0, 0, 0, 0, 0, 0, 48, 0, 0, 0, 7, 0, 0, 0
+// CHECK: rodata[59]: byte {{.*}}, 34, 0, 0, 0, 0, 0, 0, 0, 48, 0, 0, 0, 20, 0, 0, 0
+// CHECK: rodata-relocation[35] -> rodata[0]
+// CHECK: rodata-relocation[59] -> rodata[0]
 // CHECK: lddw r{{[0-9]+}}, rodata[35]
 // CHECK: lddw r{{[0-9]+}}, rodata[59]

--- a/tests/assembly/rodata_function_pointer.rs
+++ b/tests/assembly/rodata_function_pointer.rs
@@ -1,0 +1,44 @@
+// assembly-output: ptx-linker
+// compile-flags: --crate-type bin -C opt-level=3 -C panic=abort
+
+// A `Desc` value with a function pointer field lives in rodata with a relocation to text.
+// The pointer should resolve to `always_true`, and the key should remain unchanged.
+
+#![no_std]
+#![no_main]
+
+#[panic_handler]
+fn panic(_: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+pub struct Desc {
+    pub validate: fn(&[u8]) -> bool,
+    pub key: [u8; 32],
+}
+
+#[unsafe(no_mangle)]
+#[inline(never)]
+fn always_true(b: &[u8]) -> bool {
+    !b.is_empty()
+}
+
+pub static DESC: Desc = Desc {
+    validate: always_true,
+    key: [
+        0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8, 0xB1, 0xB2, 0xB3,
+        0xB4, 0xB5, 0xB6, 0xB7, 0xB8, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6,
+        0xC7, 0xC8, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7, 0xD8,
+    ],
+};
+
+#[unsafe(no_mangle)]
+pub fn entrypoint(input: *mut u8) -> u64 {
+    let probe = unsafe { core::slice::from_raw_parts(input, 1) };
+    let d: &Desc = core::hint::black_box(&DESC);
+    if (d.validate)(probe) { d.key[0] as u64 } else { 0 }
+}
+
+// CHECK: rodata[0]: byte {{.*}}161, 162, 163, 164, 165, 166, 167, 168, 177, 178, 179, 180, 181, 182, 183, 184, 193, 194, 195, 196, 197, 198, 199, 200, 209, 210, 211, 212, 213, 214, 215, 216
+// CHECK: rodata-relocation[0] -> text[{{.*}}] (always_true)
+// CHECK: label always_true

--- a/tests/assembly/rodata_pointer_table.rs
+++ b/tests/assembly/rodata_pointer_table.rs
@@ -1,0 +1,42 @@
+// assembly-output: ptx-linker
+// compile-flags: --crate-type bin -C opt-level=3 -C panic=abort
+
+// A `[&T; N]` pointer table lives in rodata with one relocation per
+// element. Each pointer should point at the matching constant.
+
+#![no_std]
+#![no_main]
+
+#[panic_handler]
+fn panic(_: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+#[repr(transparent)]
+pub struct Pubkey([u8; 32]);
+
+#[unsafe(no_mangle)]
+pub static AUTH0: Pubkey = Pubkey([1; 32]);
+#[unsafe(no_mangle)]
+pub static AUTH1: Pubkey = Pubkey([2; 32]);
+#[unsafe(no_mangle)]
+pub static AUTH2: Pubkey = Pubkey([3; 32]);
+#[unsafe(no_mangle)]
+pub static AUTH3: Pubkey = Pubkey([4; 32]);
+
+pub static REGISTRY: [&Pubkey; 4] = [&AUTH0, &AUTH1, &AUTH2, &AUTH3];
+
+#[unsafe(no_mangle)]
+pub fn entrypoint(x: *mut u8) -> u64 {
+    let i = (unsafe { core::ptr::read_volatile(x) }) as usize;
+    REGISTRY[i].0[0] as u64
+}
+
+// CHECK: rodata[0]: byte 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+// CHECK: rodata[32]: byte 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
+// CHECK: rodata[64]: byte 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3
+// CHECK: rodata[96]: byte 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4
+// CHECK: rodata-relocation[128] -> rodata[0] (AUTH0)
+// CHECK: rodata-relocation[136] -> rodata[32] (AUTH1)
+// CHECK: rodata-relocation[144] -> rodata[64] (AUTH2)
+// CHECK: rodata-relocation[152] -> rodata[96] (AUTH3)

--- a/tests/assembly/rodata_struct_field_pointer.rs
+++ b/tests/assembly/rodata_struct_field_pointer.rs
@@ -1,0 +1,34 @@
+// assembly-output: ptx-linker
+// compile-flags: --crate-type bin -C opt-level=3 -C panic=abort -C debuginfo=2
+
+// `KEYS` contains two pointers to `RECORD.key`. `key` is located 8 bytes into
+// `RECORD` struct, so each relocation should exactly point to the `key` at offset 8.
+
+#![no_std]
+#![no_main]
+
+#[panic_handler]
+fn panic(_: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+#[repr(C)]
+pub struct Record {
+    prefix: u64,
+    key: [u8; 32],
+}
+
+#[unsafe(no_mangle)]
+pub static RECORD: Record = Record { prefix: 7, key: [2; 32] };
+pub static KEYS: [&[u8; 32]; 2] = [&RECORD.key, &RECORD.key];
+
+#[unsafe(no_mangle)]
+pub fn entrypoint(input: *mut u8) -> u64 {
+    let index = (unsafe { core::ptr::read_volatile(input) } as usize);
+    let keys = core::hint::black_box(&KEYS);
+    keys[index & 1][index] as u64
+}
+
+// CHECK: rodata[0]: byte 7, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2
+// CHECK: rodata-relocation[40] -> rodata[8] (.rodata.__at__0x8)
+// CHECK: rodata-relocation[48] -> rodata[8] (.rodata.__at__0x8)

--- a/tests/byteparser.rs
+++ b/tests/byteparser.rs
@@ -1,0 +1,214 @@
+use object::write::{Object, Relocation, SectionId, Symbol, SymbolSection};
+use object::{
+    Architecture, BinaryFormat, Endianness, RelocationEncoding,
+    RelocationFlags, RelocationKind, SectionKind, SymbolFlags, SymbolKind,
+    SymbolScope,
+};
+use sbpf_assembler::{OptimizationConfig, SbpfArch, astnode::ASTNode};
+use sbpf_linker::{
+    ProgramOptions, SbpfLinkerError, byteparser::parse_bytecode,
+};
+
+const STACK_FRAME_SIZE: i32 = 4096;
+const EXIT_INSTRUCTION: [u8; 8] = [0x95, 0, 0, 0, 0, 0, 0, 0];
+
+#[test]
+fn rodata_relocation_rejects_undefined_target() {
+    let (mut object, rodata) = create_object_with_rodata(8);
+    let undefined = object.add_symbol(Symbol {
+        name: b"undefined".to_vec(),
+        value: 0,
+        size: 0,
+        kind: SymbolKind::Data,
+        scope: SymbolScope::Linkage,
+        weak: false,
+        section: SymbolSection::Undefined,
+        flags: SymbolFlags::None,
+    });
+    add_rodata_relocation(&mut object, rodata, 0, undefined, 0);
+
+    assert_rodata_relocation_error(
+        object,
+        0,
+        "relocation target has no section",
+    );
+}
+
+#[test]
+fn rodata_relocation_rejects_target_outside_rodata_and_text() {
+    let (mut object, rodata) = create_object_with_rodata(8);
+    let data = object.add_section(
+        Vec::new(),
+        b".data.test".to_vec(),
+        SectionKind::Data,
+    );
+    object.append_section_data(data, &[0; 8], 8);
+    let target = object.add_symbol(Symbol {
+        name: b"data_target".to_vec(),
+        value: 0,
+        size: 8,
+        kind: SymbolKind::Data,
+        scope: SymbolScope::Linkage,
+        weak: false,
+        section: SymbolSection::Section(data),
+        flags: SymbolFlags::None,
+    });
+    add_rodata_relocation(&mut object, rodata, 0, target, 0);
+
+    assert_rodata_relocation_error(
+        object,
+        0,
+        "relocation target is not rodata or text",
+    );
+}
+
+#[test]
+fn rodata_relocation_rejects_location_out_of_bounds() {
+    let (mut object, rodata) = create_object_with_rodata(8);
+    let rodata_section = object.section_symbol(rodata);
+    add_rodata_relocation(&mut object, rodata, 8, rodata_section, 0);
+
+    assert_rodata_relocation_error(
+        object,
+        8,
+        "relocation location out of bounds",
+    );
+}
+
+#[test]
+fn rodata_relocation_handles_interior_rodata_target() {
+    let (mut object, rodata) = create_object_with_rodata(24);
+    object.add_symbol(Symbol {
+        name: b"data".to_vec(),
+        value: 0,
+        size: 24,
+        kind: SymbolKind::Data,
+        scope: SymbolScope::Linkage,
+        weak: false,
+        section: SymbolSection::Section(rodata),
+        flags: SymbolFlags::None,
+    });
+    let rodata_section = object.section_symbol(rodata);
+    for offset in [0, 8] {
+        add_rodata_relocation(&mut object, rodata, offset, rodata_section, 16);
+    }
+
+    let program =
+        parse_object(object).expect("valid rodata relocations should parse");
+    let interior_labels = program
+        .data_section
+        .get_nodes()
+        .iter()
+        .filter(|node| {
+            matches!(
+                node,
+                ASTNode::ROData { rodata, offset }
+                    if rodata.name == ".rodata.__at__0x10" && *offset == 16
+            )
+        })
+        .count();
+    assert_eq!(interior_labels, 1);
+}
+
+#[test]
+fn rodata_relocation_handles_interior_text_target() {
+    let (mut object, rodata) = create_object_with_rodata(8);
+    let text =
+        object.add_section(Vec::new(), b".text".to_vec(), SectionKind::Text);
+    object.append_section_data(text, &EXIT_INSTRUCTION.repeat(2), 8);
+    object.add_symbol(Symbol {
+        name: b"entrypoint".to_vec(),
+        value: 0,
+        size: EXIT_INSTRUCTION.len() as u64,
+        kind: SymbolKind::Text,
+        scope: SymbolScope::Linkage,
+        weak: false,
+        section: SymbolSection::Section(text),
+        flags: SymbolFlags::None,
+    });
+    let text_section = object.section_symbol(text);
+    add_rodata_relocation(&mut object, rodata, 0, text_section, 8);
+
+    let program =
+        parse_object(object).expect("valid text relocation should parse");
+    assert!(program.code_section.get_nodes().iter().any(|node| {
+        matches!(
+            node,
+            ASTNode::Label { label, offset }
+                if label.name == ".text.__at__0x8" && *offset == 8
+        )
+    }));
+}
+
+fn create_object_with_rodata(size: usize) -> (Object<'static>, SectionId) {
+    let mut object =
+        Object::new(BinaryFormat::Elf, Architecture::Sbf, Endianness::Little);
+    let rodata = object.add_section(
+        Vec::new(),
+        b".rodata".to_vec(),
+        SectionKind::ReadOnlyData,
+    );
+    object.append_section_data(rodata, &vec![0; size], 8);
+    (object, rodata)
+}
+
+fn add_rodata_relocation(
+    object: &mut Object<'_>,
+    rodata: SectionId,
+    offset: u64,
+    symbol: object::write::SymbolId,
+    addend: i64,
+) {
+    object
+        .add_relocation(
+            rodata,
+            Relocation {
+                offset,
+                symbol,
+                addend,
+                flags: RelocationFlags::Generic {
+                    kind: RelocationKind::Absolute,
+                    encoding: RelocationEncoding::Generic,
+                    size: 64,
+                },
+            },
+        )
+        .expect("failed to add rodata relocation");
+}
+
+fn parse_object(
+    object: Object<'_>,
+) -> Result<sbpf_assembler::ProgramLayout, SbpfLinkerError> {
+    let bytes = object.write().expect("failed to write object");
+    parse_bytecode(
+        &bytes,
+        ProgramOptions::new(
+            OptimizationConfig::enabled(),
+            SbpfArch::V0,
+            STACK_FRAME_SIZE,
+        ),
+    )
+}
+
+fn assert_rodata_relocation_error(
+    object: Object<'_>,
+    expected_address: u64,
+    expected_detail: &str,
+) {
+    let error = match parse_object(object) {
+        Ok(_) => panic!("expected rodata relocation to fail"),
+        Err(error) => error,
+    };
+    match error {
+        SbpfLinkerError::RodataRelocationError {
+            section,
+            address,
+            detail,
+        } => {
+            assert_eq!(section, ".rodata");
+            assert_eq!(address, expected_address);
+            assert_eq!(detail, expected_detail);
+        }
+        _ => panic!("expected RodataRelocationError"),
+    }
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,7 +1,7 @@
 #![allow(unused_crate_dependencies, reason = "used in test harness")]
 
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     env,
     ffi::OsString,
     fs, io,
@@ -10,7 +10,7 @@ use std::{
 };
 
 use either::Either;
-use object::{File, Object as _, ObjectSection as _};
+use object::{File, Object as _, ObjectSection as _, ObjectSymbol as _};
 use sbpf_assembler::{
     OptimizationConfig, SbpfArch,
     astnode::{ASTNode, ROData},
@@ -292,6 +292,15 @@ fn render_emitted_program<A: TestArch>(path: &Path) -> anyhow::Result<String> {
         }
     }
 
+    out.extend(render_rodata_relocations::<A>(
+        &bytes,
+        rodata_nodes,
+        rodata_base,
+        rodata_len,
+        parse_result.code_section.get_size(),
+        &code_labels,
+    )?);
+
     for node in code_nodes {
         match node {
             ASTNode::Label { label, offset } => {
@@ -418,4 +427,173 @@ fn render_rodata(rodata: &ROData) -> anyhow::Result<String> {
             rodata.name
         )),
     }
+}
+
+fn render_rodata_relocations<A: TestArch>(
+    bytes: &[u8],
+    rodata_nodes: &[ASTNode],
+    rodata_base: u64,
+    rodata_len: u64,
+    text_len: u64,
+    code_labels: &HashMap<i64, String>,
+) -> anyhow::Result<Vec<String>> {
+    let obj = File::parse(bytes)?;
+    let rodata_vaddr =
+        ProgramHeader::new_load(rodata_base, rodata_len, false, A::ARCH)
+            .p_vaddr;
+    let mut relocation_lines = BTreeMap::new();
+    for section in obj.sections().filter(|section| {
+        section.name().is_ok_and(|name| {
+            name.starts_with(".rodata") || name.starts_with(".data.rel.ro")
+        })
+    }) {
+        for (input_offset, _) in section.relocations() {
+            let mut relocation = None;
+            for node in rodata_nodes {
+                let ASTNode::ROData { rodata, offset } = node else {
+                    continue;
+                };
+                let symbol = obj.symbols().find(|symbol| {
+                    symbol.name().is_ok_and(|name| name == rodata.name)
+                        && symbol.section_index().is_some()
+                });
+
+                let Some(symbol) = symbol else {
+                    if rodata.name.starts_with(".rodata.__at__") {
+                        continue;
+                    }
+
+                    return Err(anyhow::anyhow!(
+                        "no symbol found for rodata: {}",
+                        rodata.name
+                    ));
+                };
+                let section_index = symbol.section_index().unwrap().0;
+                let address = symbol.address();
+                if section_index != section.index().0 {
+                    continue;
+                }
+
+                let Some(offset_in_node) = input_offset.checked_sub(address)
+                else {
+                    continue;
+                };
+
+                let node_bytes = match rodata.args.get(1) {
+                    Some(Token::VectorLiteral(node_bytes, _)) => {
+                        node_bytes.as_slice()
+                    }
+                    _ => {
+                        return Err(anyhow::anyhow!(
+                            "rodata {} is not a byte vector",
+                            rodata.name
+                        ));
+                    }
+                };
+                if offset_in_node < node_bytes.len() as u64 {
+                    relocation = Some((
+                        rodata,
+                        *offset + offset_in_node,
+                        offset_in_node,
+                    ));
+                    break;
+                }
+            }
+
+            let (relocation_rodata, output_offset, offset_in_node) =
+                relocation.ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "invalid rodata relocation: {input_offset:#x}",
+                    )
+                })?;
+
+            let offset_in_node = usize::try_from(offset_in_node)?;
+            let relocation_bytes = match relocation_rodata.args.get(1) {
+                Some(Token::VectorLiteral(node_bytes, _)) => node_bytes
+                    .get(offset_in_node..offset_in_node + 8)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "relocation in rodata {} is out of bounds",
+                            relocation_rodata.name
+                        )
+                    })?,
+                _ => {
+                    return Err(anyhow::anyhow!(
+                        "rodata {} is not a byte vector",
+                        relocation_rodata.name
+                    ));
+                }
+            };
+            let mut encoded_target = [0u8; 8];
+            for (byte, value) in
+                encoded_target.iter_mut().zip(relocation_bytes)
+            {
+                let Number::Int(value) = value else {
+                    return Err(anyhow::anyhow!(
+                        "relocation in rodata {} contains non-integer byte",
+                        relocation_rodata.name
+                    ));
+                };
+                *byte = u8::try_from(*value).map_err(|_| {
+                    anyhow::anyhow!(
+                        "relocation in rodata {} contains invalid byte {value}",
+                        relocation_rodata.name
+                    )
+                })?;
+            }
+
+            let encoded_target = u64::from_le_bytes(encoded_target);
+            let target_vaddr = if A::ARCH.is_v3() {
+                encoded_target
+            } else {
+                encoded_target >> 32
+            };
+
+            let text_vaddr = ProgramHeader::new_load(
+                rodata_base - text_len,
+                text_len,
+                true,
+                A::ARCH,
+            )
+            .p_vaddr;
+            let target = if let Some(text_off) = target_vaddr
+                .checked_sub(text_vaddr)
+                .filter(|address| *address < text_len)
+            {
+                match code_labels.get(&(text_off as i64)) {
+                    Some(name) => format!("text[{text_off}] ({name})"),
+                    None => format!("text[{text_off}]"),
+                }
+            } else if let Some(target_address_out) = target_vaddr
+                .checked_sub(rodata_vaddr)
+                .filter(|address| *address < rodata_len)
+            {
+                let target_name = rodata_nodes.iter().find_map(|node| {
+                    let ASTNode::ROData { rodata, offset } = node else {
+                        return None;
+                    };
+                    if *offset == target_address_out {
+                        return Some(rodata.name.as_str());
+                    }
+                    None
+                });
+                match target_name {
+                    Some(name) => {
+                        format!("rodata[{target_address_out}] ({name})")
+                    }
+                    None => format!("rodata[{target_address_out}]"),
+                }
+            } else {
+                return Err(anyhow::anyhow!(
+                    "relocation in rodata {} targets an address outside text and rodata",
+                    relocation_rodata.name
+                ));
+            };
+            relocation_lines.insert(
+                output_offset,
+                format!("rodata-relocation[{output_offset}] -> {target}"),
+            );
+        }
+    }
+    Ok(relocation_lines.into_values().collect())
 }


### PR DESCRIPTION
### Summary

sbpf-linker currently only handles text relocations and does not handle relocations in read-only data sections such as `.rodata` and `.data.rel.ro`. As a result, pointers stored in rodata (for example, a `[&T; N]` pointer table, function pointer, etc.) are emitted with their original, unrelocated bytes and no relocation is generated to fix them at load time.

For example, with the following code (also covered by the rodata_pointer_table.rs test):

```
static REGISTRY: [&Pubkey; 4] = [&AUTH0, &AUTH1, &AUTH2, &AUTH3];
```

the four pointer slots are emitted with unrelocated values and no relocations. On v0, these are not valid load addresses, so accessing REGISTRY[i] results in an `AccessViolation` error. On v3 (where rodata is mapped at address 0), the unrelocated values are used as-is. They may happen to point to the correct data or silently resolve to the wrong value, without necessarily crashing.

---

This fix parses relocations from read-only ELF sections and records them in the assembler AST using `AST::add_rodata_relocation`. This allows rodata-to-rodata and rodata-to-text references to be correctly resolved when emitting the final sBPF program.

Depends on https://github.com/blueshift-gg/sbpf/pull/162
